### PR TITLE
add support for random_bytes

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -129,7 +129,12 @@ class Guard implements ServiceProviderInterface
     {
         $token = "";
 
-        if (function_exists("openssl_random_pseudo_bytes")) {
+        if (function_exists("random_bytes")) {
+            $rawToken = random_bytes($this->strength);
+            if ($rawToken !== false) {
+                $token = bin2hex($token);
+            }
+        } else if (function_exists("openssl_random_pseudo_bytes")) {
             $rawToken = openssl_random_pseudo_bytes($this->strength);
             if ($rawToken !== false) {
                 $token = bin2hex($token);


### PR DESCRIPTION
`random_bytes` can be used in PHP 7.0 alpha and I didn't see any issue in the [result](https://gist.github.com/masakielastic/76ec50728d259626cf14) of benchmark.