### PR TITLE
Retrieve token keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ $app->add(new \Slim\Csrf\Guard);
 
 $app->get('/foo', function ($req, $res, $args) {
     // CSRF token name and value
-    $name = $req->getAttribute('csrf_name');
-    $value = $req->getAttribute('csrf_value');
+    $name = $req->getAttribute($this->csrf->getTokenNameKey());
+    $value = $req->getAttribute($this->csrf->getTokenValueKey());
 
     // Render HTML form hidden input with this
     // CSRF token name and value.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/http-message": "1.0"
     },
     "require-dev": {
-        "slim/slim": "dev-develop"
+        "slim/slim": "3.0.0-beta2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/http-message": "1.0"
     },
     "require-dev": {
-        "slim/slim": "3.0.0-beta2"
+        "slim/slim": "3.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -69,7 +69,7 @@ class Guard implements ServiceProviderInterface
     /**
      * Retrieve token name key
      *
-     * @return string;
+     * @return string
      */
     public function getTokenNameKey()
     {
@@ -79,7 +79,7 @@ class Guard implements ServiceProviderInterface
     /**
      * Retrieve token value key
      *
-     * @return string;
+     * @return string
      */
     public function getTokenValueKey()
     {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -67,6 +67,26 @@ class Guard implements ServiceProviderInterface
     }
 
     /**
+     * Retrieve token name key
+     *
+     * @return string;
+     */
+    public function getTokenNameKey()
+    {
+        return $this->prefix . '_name';
+    }
+
+    /**
+     * Retrieve token value key
+     *
+     * @return string;
+     */
+    public function getTokenValueKey()
+    {
+        return $this->prefix . '_value';
+    }
+
+    /**
      * Invoke middleware
      *
      * @param  RequestInterface  $request  PSR7 request object

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -43,6 +43,14 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->response = new Response;
     }
 
+    public function testTokenKeys()
+    {
+        $mw = new Guard('test');
+
+        $this->assertEquals('test_name', $mw->getTokenNameKey());
+        $this->assertEquals('test_value', $mw->getTokenValueKey());
+    }
+
     public function testValidToken()
     {
         $storage = ['csrf_123' => 'xyz'];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,4 @@
 <?php
 require dirname(__DIR__) . '/vendor/autoload.php';
+
+session_start();


### PR DESCRIPTION
# Problem

Though we set prefix on Guard construction we are required to remember it later when selecting generated token parts from request (we even need to know they are called `<prefix>_name` and `<prefix>_value`

```
$app->get('/foo', function ($req, $res, $args) {
    // CSRF token name and value
    $name = $req->getAttribute('csrf_name');
    $value = $req->getAttribute('csrf_value');

    // Render HTML form hidden input with this
    // CSRF token name and value.
});
```

# Solution

As long as the Guard is already registered as a service in the container (`csrf`) we can provide two methods to retrieve those keys on the routes, `getTokenNameKey` and `getTokenValueKey` this way even if we change the keys in the future we'll have BC