### PR TITLE
Remove Pimple service provider interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "pimple/pimple": "~3.0",
         "psr/http-message": "1.0"
     },
     "require-dev": {

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -5,8 +5,6 @@ use ArrayAccess;
 use RuntimeException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Pimple\Container;
-use Pimple\ServiceProviderInterface;
 
 /**
  * CSRF protection middleware based
@@ -14,7 +12,7 @@ use Pimple\ServiceProviderInterface;
  *
  * @link https://www.owasp.org/index.php/PHP_CSRF_Guard
  */
-class Guard implements ServiceProviderInterface
+class Guard
 {
     /**
      * Prefix for CSRF parameters (omit trailing "_" underscore)
@@ -54,16 +52,6 @@ class Guard implements ServiceProviderInterface
             }
             $this->storage = &$_SESSION;
         }
-    }
-
-    /**
-     * Register service provider
-     *
-     * @param  \Pimple\Container $container
-     */
-    public function register(Container $container)
-    {
-        $container['csrf'] = $this;
     }
 
     /**


### PR DESCRIPTION
Registering manually makes more sense when we don't know the DIC being used.

Closes #11
