### PR TITLE
Empty csrf token failure callable fix

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -107,29 +107,36 @@ class Guard
             $name = isset($body[$this->prefix . '_name']) ? $body[$this->prefix . '_name'] : false;
             $value = isset($body[$this->prefix . '_value']) ? $body[$this->prefix . '_value'] : false;
             if (!$name || !$value || !$this->validateToken($name, $value)) {
-				// Need to regenerate a new token, as the validateToken removed the current one.
-				$request = $this->generateNewToken($request);
-				
+                // Need to regenerate a new token, as the validateToken removed the current one.
+                $request = $this->generateNewToken($request);
+
                 $failureCallable = $this->getFailureCallable();
                 return $failureCallable($request, $response, $next);
             }
         }
-		// Generate new CSRF token
-		$request = $this->generateNewToken($request);        
+        // Generate new CSRF token
+        $request = $this->generateNewToken($request);
 
         return $next($request, $response);
     }
-	
-	protected function generateNewToken($request){
-		// Generate new CSRF token
+
+    /**
+     * Generates a new CSRF token and appends it to the request.
+     *
+     * @param  RequestInterface $request PSR7 response object.
+     *
+     * @return RequestInterface PSR7 response object.
+     */
+    protected function generateNewToken($request){
+        // Generate new CSRF token
         $name = $this->prefix . mt_rand(0, mt_getrandmax());
         $value = $this->createToken();
         $this->saveToStorage($name, $value);
         $request = $request->withAttribute($this->prefix . '_name', $name)
-                           ->withAttribute($this->prefix . '_value', $value);
-	   
-		return $request;
-	}
+            ->withAttribute($this->prefix . '_value', $value);
+
+        return $request;
+    }
 
     /**
      * Validate CSRF token from current request


### PR DESCRIPTION
With the update for the failureCallable today (5ccec2b436b4dee8b84c6ed877f4af2ab371befc), if it's used, the CSRF tokens in that rendered request will be empty, as the validateToken removes the current one, and no new one is set.

I've also moved the creation of the token to a separate method.