### PR TITLE
Limit storage array size

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -141,7 +141,8 @@ class Guard
      *
      * @return RequestInterface PSR7 response object.
      */
-    protected function generateNewToken($request){
+    protected function generateNewToken($request)
+    {
         // Generate new CSRF token
         $name = $this->prefix . mt_rand(0, mt_getrandmax());
         $value = $this->createToken();

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -29,6 +29,13 @@ class Guard
     protected $storage;
 
     /**
+     * Number of elements to store in the storage array
+     *
+     * @var integer
+     */
+    protected $storageLimit = 200;
+
+    /**
      * CSRF Strength
      *
      * @var int
@@ -233,6 +240,20 @@ class Guard
     {
         $this->storage[$name] = ' ';
         unset($this->storage[$name]);
+    }
+
+    /**
+     * Remove the oldest tokens from the storage array so that there
+     * are never more than storageLimit tokens in the array.
+     *
+     * This is required as a token is generated every request and so
+     * most will never be used.
+     */
+    protected function enforceStorageLimit()
+    {
+        while (count($this->storage) > $this->storageLimit) {
+            array_shift($this->storage);
+        }
     }
 
     /**

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -35,9 +35,11 @@ class Guard
     /**
      * Number of elements to store in the storage array
      *
+     * Default is 200, set via constructor
+     *
      * @var integer
      */
-    protected $storageLimit = 200;
+    protected $storageLimit;
 
     /**
      * CSRF Strength
@@ -63,9 +65,10 @@ class Guard
      * @param string                 $prefix
      * @param null|array|ArrayAccess $storage
      * @param null|callable          $failureCallable
+     * @param integer                $storageLimit
      * @throws RuntimeException if the session cannot be found
      */
-    public function __construct($prefix = 'csrf', $storage = null, callable $failureCallable = null)
+    public function __construct($prefix = 'csrf', $storage = null, callable $failureCallable = null, $storageLimit = 200)
     {
         $this->prefix = rtrim($prefix, '_');
         if (is_array($storage) || $storage instanceof ArrayAccess) {
@@ -78,6 +81,7 @@ class Guard
         }
 
         $this->setFailureCallable($failureCallable);
+        $this->setStorageLimit($storageLimit);
     }
 
     /**

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -284,4 +284,15 @@ class Guard
         $this->failureCallable = $failureCallable;
         return $this;
     }
+
+    /**
+     * Setter for storageLimit
+     *
+     * @param integer $storageLimit Value to set
+     */
+    public function setStorageLimit($storageLimit)
+    {
+        $this->storageLimit = (int)$storageLimit;
+        return $this;
+    }
 }


### PR DESCRIPTION
Remove the oldest tokens from the storage array so that there are never more than storageLimit tokens in the array. This is required as a token is generated every request and so most will never be used.

I've picked 200 as an arbitrary number on the assumption that for any given form, the user is unlikely to make 200 more requests before submitting it.
