### PR TITLE
Set default session storage to a sub-array

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -77,7 +77,10 @@ class Guard
             if (!isset($_SESSION)) {
                 throw new RuntimeException('CSRF middleware failed. Session not found.');
             }
-            $this->storage = &$_SESSION;
+            if (!array_key_exists($prefix, $_SESSION)) {
+                $_SESSION[$prefix] = [];
+            }
+            $this->storage = &$_SESSION[$prefix];
         }
 
         $this->setFailureCallable($failureCallable);


### PR DESCRIPTION
This is so that we can remove the old ones safely and not impact any other session key when we enforce the storage limit. 

Found by @vlakoff
