### PR TITLE
Fix external storage

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -3,7 +3,7 @@ namespace Slim\Csrf;
 
 use ArrayAccess;
 use Countable;
-use Iterator;
+use Traversable;
 use IteratorAggregate;
 use RuntimeException;
 use Psr\Http\Message\RequestInterface;
@@ -272,10 +272,9 @@ class Guard
             return;
         }
 
-        // $storage must be an array or implement Countable and either Iterator or IteratorAggregate
+        // $storage must be an array or implement Countable and Traversable
         if (!is_array($this->storage)
-            && !($this->storage instanceof Countable
-                && ($this->storage instanceof Iterator || $this->storage instanceof IteratorAggregate))
+            && !($this->storage instanceof Countable && $this->storage instanceof Traversable)
         ) {
             return;
         }

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -3,6 +3,8 @@ namespace Slim\Csrf;
 
 use ArrayAccess;
 use Countable;
+use Iterator;
+use IteratorAggregate;
 use RuntimeException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -25,8 +27,9 @@ class Guard
     /**
      * CSRF storage
      *
-     * Should be either an array or an object that implements
-     * ArrayAccess and Countable.
+     * Should be either an array or an object. If an object is used, then it must
+     * implement ArrayAccess and should implement Countable and Iterator (or
+     * IteratorAggregate) if storage limit enforcement is required.
      *
      * @var array|ArrayAccess
      */
@@ -269,12 +272,29 @@ class Guard
             return;
         }
 
-        if (!is_array($this->storage) && !$this->storage instanceof Countable) {
+        // $storage must be an array or implement Countable and either Iterator or IteratorAggregate
+        if (!is_array($this->storage)
+            && !($this->storage instanceof Countable
+                && ($this->storage instanceof Iterator || $this->storage instanceof IteratorAggregate))
+        ) {
             return;
         }
 
-        while (count($this->storage) > $this->storageLimit) {
-            array_shift($this->storage);
+        if (is_array($this->storage)) {
+            while (count($this->storage) > $this->storageLimit) {
+                array_shift($this->storage);
+            }
+        } else {
+            // array_shift() doesn't work for ArrayAccess, so we need an iterator in order to use rewind()
+            // and key(), so that we can then unset
+            $iterator = $this->storage;
+            if ($this->storage instanceof \IteratorAggregate) {
+                $iterator = $this->storage->getIterator();
+            }
+            while (count($this->storage) > $this->storageLimit) {
+                $iterator->rewind();
+                unset($this->storage[$iterator->key()]);
+            }
         }
     }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -68,10 +68,12 @@ class Guard
      * @param integer                $storageLimit
      * @throws RuntimeException if the session cannot be found
      */
-    public function __construct($prefix = 'csrf', $storage = null, callable $failureCallable = null, $storageLimit = 200)
+    public function __construct($prefix = 'csrf', &$storage = null, callable $failureCallable = null, $storageLimit = 200)
     {
         $this->prefix = rtrim($prefix, '_');
-        if (is_array($storage) || $storage instanceof ArrayAccess) {
+        if (is_array($storage)) {
+            $this->storage = &$storage;
+        } elseif ($storage instanceof ArrayAccess) {
             $this->storage = $storage;
         } else {
             if (!isset($_SESSION)) {

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -107,4 +107,46 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(400, $newResponse->getStatusCode());
     }
+
+    public function testExternalStorageOfAnArrayAccessPersists()
+    {
+        $storage = new \ArrayObject();
+        
+        $request = $this->request
+                        ->withMethod('POST')
+                        ->withParsedBody([
+                            'csrf_name' => 'csrf_123',
+                            'csrf_value' => 'xyz'
+                        ]);
+        $response = $this->response;
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $mw = new Guard('csrf', $storage);
+
+        $this->assertEquals(0, count($storage));
+        $newResponse = $mw($request, $response, $next);
+        $this->assertEquals(1, count($storage));
+    }
+
+    public function testExternalStorageOfAnArrayPersists()
+    {
+        $storage = [];
+        
+        $request = $this->request
+                        ->withMethod('POST')
+                        ->withParsedBody([
+                            'csrf_name' => 'csrf_123',
+                            'csrf_value' => 'xyz'
+                        ]);
+        $response = $this->response;
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $mw = new Guard('csrf', $storage);
+
+        $this->assertEquals(0, count($storage));
+        $newResponse = $mw($request, $response, $next);
+        $this->assertEquals(1, count($storage));
+    }
 }

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -149,4 +149,42 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $newResponse = $mw($request, $response, $next);
         $this->assertEquals(1, count($storage));
     }
+
+    public function testStorageLimitIsEnforcedForObjects()
+    {
+        $storage = new \ArrayObject();
+        
+        $request = $this->request;
+        $response = $this->response;
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $mw = new Guard('csrf', $storage);
+        $mw->setStorageLimit(2);
+
+        $this->assertEquals(0, count($storage));
+        $response = $mw($request, $response, $next);
+        $response = $mw($request, $response, $next);
+        $response = $mw($request, $response, $next);
+        $this->assertEquals(2, count($storage));
+    }
+
+    public function testStorageLimitIsEnforcedForArrays()
+    {
+        $storage = [];
+        
+        $request = $this->request;
+        $response = $this->response;
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $mw = new Guard('csrf', $storage);
+        $mw->setStorageLimit(2);
+
+        $this->assertEquals(0, count($storage));
+        $response = $mw($request, $response, $next);
+        $response = $mw($request, $response, $next);
+        $response = $mw($request, $response, $next);
+        $this->assertEquals(2, count($storage));
+    }
 }


### PR DESCRIPTION
This PR fixes two things related to passing in `$storage` in the constructor:
1. Ensure that the changes made inside the class are reflected back in the original item.
2. Fix `enforceStorageLimit()` so that it works with objects as `array_shift()` doesn't.

I also added tests for these cases.
