### PR TITLE
Correct variable usage + Strength as parameter

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -76,6 +76,7 @@ class Guard
      * @param null|array|ArrayAccess $storage
      * @param null|callable          $failureCallable
      * @param integer                $storageLimit
+     * @param integer                $strength
      * @throws RuntimeException if the session cannot be found
      */
     public function __construct(
@@ -86,6 +87,9 @@ class Guard
         $strength = 16
     ) {
         $this->prefix = rtrim($prefix, '_');
+        if ($strength < 16) {
+            throw new RuntimeException('CSRF middleware failed. Minimum strength is 16.');
+        }
         $this->strength = $strength;
         if (is_array($storage)) {
             $this->storage = &$storage;

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -49,7 +49,7 @@ class Guard
      *
      * @var int
      */
-     protected $strength = 16;
+     protected $strength;
 
     /**
      * Callable to be executed if the CSRF validation fails
@@ -82,9 +82,11 @@ class Guard
         $prefix = 'csrf',
         &$storage = null,
         callable $failureCallable = null,
-        $storageLimit = 200
+        $storageLimit = 200,
+        $strength = 16
     ) {
         $this->prefix = rtrim($prefix, '_');
+        $this->strength = $strength;
         if (is_array($storage)) {
             $this->storage = &$storage;
         } elseif ($storage instanceof ArrayAccess) {
@@ -218,12 +220,12 @@ class Guard
         if (function_exists("random_bytes")) {
             $rawToken = random_bytes($this->strength);
             if ($rawToken !== false) {
-                $token = bin2hex($token);
+                $token = bin2hex($rawToken);
             }
         } elseif (function_exists("openssl_random_pseudo_bytes")) {
             $rawToken = openssl_random_pseudo_bytes($this->strength);
             if ($rawToken !== false) {
-                $token = bin2hex($token);
+                $token = bin2hex($rawToken);
             }
         }
 


### PR DESCRIPTION
Hi, it's my first pull request !

- "random_bytes" and "openssl_random_pseudo_bytes" may be call, but result was never used.
- add strength as constructor parameter

Sylfel.