### PR TITLE
Allow paragonie/random_compat 2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.0",
         "psr/http-message": "^1.0",
-        "paragonie/random_compat": "^1.1"
+        "paragonie/random_compat": "^1.1|^2.0"
     },
     "require-dev": {
         "slim/slim": "~3.0",


### PR DESCRIPTION
`paragonie/random_compat` ^2.0 is required for other packages, such as `ramsey/uuid`. `slim/csrf` appears to work fine with 2.0 as well as 1.0.

Please accept pull request to allow `slim/csrf` to use `paragonie/random_compat` 2.0 so that it can be installed without forking when other 2.0-using packages are installed. `paragonie/random_compat` 1.0 is now very old.

PR allows both versions for backwards compatibility.