### PR TITLE
Default storage restored to $_SESSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ $app->post('/api/myEndPoint',function ($request, $response, $args) {
 $app->run();
 ```
 
+### Manual usage
+
+If you are willing to use `Slim\Csrf\Guard` outside a `Slim\App` or not as a middleware, be careful to validate the storage:
+
+```php
+// Start PHP session
+session_start();
+
+$slimGuard = new \Slim\Csrf\Guard;
+$slimGuard->validateStorage();
+
+// Generate new tokens
+$csrfNameKey = $slimGuard->getTokenNameKey();
+$csrfValueKey = $slimGuard->getTokenValueKey();
+$keyPair = $slimGuard->generateToken();
+
+// Validate retrieved tokens
+$slimGuard->validateToken($_POST[$csrfNameKey], $_POST[$csrfValueKey]);
+```
+
 ## Token persistence
 
 By default, `Slim\Csrf\Guard` will generate a fresh name/value pair after each request.  This is an important security measure for [certain situations](http://blog.ircmaxell.com/2013/02/preventing-csrf-attacks.html).  However, in many cases this is unnecessary, and [a single token throughout the user's session will suffice](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Synchronizer_.28CSRF.29_Tokens).  By using per-session requests it becomes easier, for example, to process AJAX requests without having to retrieve a new CSRF token (by reloading the page or making a separate request) after each request.  See issue #49.

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -172,22 +172,24 @@ class Guard
      * @param $storage
      * @return mixed
      */
-    private function validateStorage()
+    public function validateStorage()
     {
         if (is_array($this->storage)) {
             return $this->storage;
-        } elseif ($this->storage instanceof ArrayAccess) {
-            return $this->storage;
-        } else {
-            if (!isset($_SESSION)) {
-                throw new RuntimeException('CSRF middleware failed. Session not found.');
-            }
-            if (!array_key_exists($this->prefix, $_SESSION)) {
-                $_SESSION[$this->prefix] = [];
-            }
-            $this->storage = &$_SESSION[$this->prefix];
+        }
+
+        if ($this->storage instanceof ArrayAccess) {
             return $this->storage;
         }
+
+        if (!isset($_SESSION)) {
+            throw new RuntimeException('CSRF middleware failed. Session not found.');
+        }
+        if (!array_key_exists($this->prefix, $_SESSION)) {
+            $_SESSION[$this->prefix] = [];
+        }
+        $this->storage = &$_SESSION[$this->prefix];
+        return $this->storage;
     }
 
     /**

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -393,4 +393,17 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($mw->getTokenValue());
     }
+
+    public function testDefaultStorageIsSession()
+    {
+        $sessionBackup = $_SESSION;
+        $_SESSION = array();
+
+        $mw = new Guard('csrf');
+        $mw->validateStorage();
+
+        $this->assertNotEmpty($_SESSION);
+
+        $_SESSION = $sessionBackup;
+    }
 }


### PR DESCRIPTION
Hi, I'm using `Guard` not as a middleware but as a standalone component, so in my app I never call `__invoke` method.

The PR https://github.com/slimphp/Slim-Csrf/pull/55 introduced a BC break since after that I have to manually instantiate Guard with something like this:
```php
$prefix = 'csrf';
if (! isset($_SESSION[$prefix])) {
    $_SESSION[$prefix] = array();
}
$csrf = new \Slim\Csrf\Guard($prefix, $_SESSION[$prefix]);
```
Setting the new method `validateStorage` to public let me call it manually and retain default behaviour.