### PR TITLE
Attach token name and value to request when persist mode is on

### DIFF
--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -182,7 +182,10 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $mw = new Guard('csrf', $storage, null, 200, 16, true);
 
-        $next = function ($req, $res) {
+        $next = function ($req, $res) use ($mw) {
+            // Token name and value should be accessible in the middleware as request attributes
+            $this->assertEquals($mw->getTokenName(), $req->getAttribute('csrf_name'));
+            $this->assertEquals($mw->getTokenValue(), $req->getAttribute('csrf_value'));
             return $res;
         };
 
@@ -216,7 +219,10 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $mw = new Guard('csrf', $storage, null, 200, 16, true);
 
-        $next = function ($req, $res) {
+        $next = function ($req, $res) use ($mw) {
+            // Token name and value should be accessible in the middleware as request attributes
+            $this->assertEquals($mw->getTokenName(), $req->getAttribute('csrf_name'));
+            $this->assertEquals($mw->getTokenValue(), $req->getAttribute('csrf_value'));
             return $res;
         };
 
@@ -250,7 +256,10 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $mw = new Guard('csrf', $storage);
 
-        $next = function ($req, $res) {
+        $next = function ($req, $res) use ($mw) {
+            // Token name and value should be accessible in the middleware as request attributes
+            $this->assertEquals($mw->getTokenName(), $req->getAttribute('csrf_name'));
+            $this->assertEquals($mw->getTokenValue(), $req->getAttribute('csrf_value'));
             return $res;
         };
 
@@ -284,7 +293,10 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $mw = new Guard('csrf', $storage);
 
-        $next = function ($req, $res) {
+        $next = function ($req, $res) use ($mw) {
+            // Token name and value should be accessible in the middleware as request attributes
+            $this->assertEquals($mw->getTokenName(), $req->getAttribute('csrf_name'));
+            $this->assertEquals($mw->getTokenValue(), $req->getAttribute('csrf_value'));
             return $res;
         };
 


### PR DESCRIPTION
*This PR is duplicate of PR #67 because I accidentally deleted the forked repository.*

PR #60 introduced persist mode for the token, but there is a BC break. When the persist mode is turned on the token name and value are not attached to the request. This fixes the issue.

PS: @akrabat please add Style CI or something else to format the code in PSR2 because PhpStorm automatically does some whitespace changes and stuff on save and I know from my previous PR that you don't like these.
