### PR TITLE
Widen random_compat constraint to include versions 9.99.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5.0",
         "psr/http-message": "^1.0",
-        "paragonie/random_compat": "^1.1|^2.0"
+        "paragonie/random_compat": "^1.1|^2.0|^9.99"
     },
     "require-dev": {
         "slim/slim": "~3.0",


### PR DESCRIPTION
[random_compat](https://github.com/paragonie/random_compat) uses version 9.99.99 for PHP 7+ installs ([Source](https://github.com/paragonie/random_compat#version-99999)).

I've widened the constraint for the library to include `^9.99.99`.