### PR TITLE
Added raw body fallback

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -146,6 +146,12 @@ class Guard
         if (in_array($request->getMethod(), ['POST', 'PUT', 'DELETE', 'PATCH'])) {
             $body = $request->getParsedBody();
             $body = $body ? (array)$body : [];
+            
+            if( empty($body) ) {
+                $body = $request->getBody();
+                $body = $body ? (array)json_decode($body) : [];
+            }
+            
             $name = isset($body[$this->prefix . '_name']) ? $body[$this->prefix . '_name'] : false;
             $value = isset($body[$this->prefix . '_value']) ? $body[$this->prefix . '_value'] : false;
             if (!$name || !$value || !$this->validateToken($name, $value)) {


### PR DESCRIPTION
Added in a check to check the raw body for a JSON object that might contain the CSRF tokens. Like when sent via the fetch JavaScript method.