### PR TITLE
Make remoteTokenFromStorage method public

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -332,7 +332,7 @@ class Guard implements MiddlewareInterface
      *
      * @param  string $name CSRF token name
      */
-    protected function removeTokenFromStorage(string $name): void
+    public function removeTokenFromStorage(string $name): void
     {
         $this->storage[$name] = '';
         unset($this->storage[$name]);


### PR DESCRIPTION
Fix for #113 

This is a breaking change if you've extended `Guard` and overloaded the `removeTokenFromStorage()` method.