### PR TITLE
Minor improvements in code complexity with early returns and early validation

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -81,7 +81,7 @@ class Guard implements MiddlewareInterface
      *
      * @var array|null
      */
-    protected $keyPair;
+    protected $keyPair = null;
 
     /**
      * @param ResponseFactoryInterface  $responseFactory
@@ -102,20 +102,18 @@ class Guard implements MiddlewareInterface
         int $strength = 16,
         bool $persistentTokenMode = false
     ) {
-        $this->responseFactory = $responseFactory;
-        $this->prefix = rtrim($prefix, '_');
-
         if ($strength < 16) {
             throw new RuntimeException('CSRF middleware instantiation failed. Minimum strength is 16.');
         }
+
+        $this->responseFactory = $responseFactory;
+        $this->prefix = rtrim($prefix, '_');
         $this->strength = $strength;
 
         $this->setStorage($storage);
         $this->setFailureHandler($failureHandler);
         $this->setStorageLimit($storageLimit);
         $this->setPersistentTokenMode($persistentTokenMode);
-
-        $this->keyPair = null;
     }
 
     /**

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -244,6 +244,22 @@ class GuardTest extends TestCase
         $this->assertArrayHasKey('test_name2', $storage);
     }
 
+    public function testNotEnforceStorageLimitWithArrayWhenLimitIsZero()
+    {
+        $initial_storage = $storage = [
+            'test_name' => 'value',
+            'test_name2' => 'value2',
+        ];
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $mw = new Guard($responseFactoryProphecy->reveal(), 'test', $storage, null, 0);
+
+        $enforceStorageLimitMethod = new ReflectionMethod($mw, 'enforceStorageLimit');
+        $enforceStorageLimitMethod->setAccessible(true);
+        $enforceStorageLimitMethod->invoke($mw);
+
+        $this->assertSame($initial_storage, $storage);
+    }
+
     public function testEnforceStorageLimitWithIterator()
     {
         $storage = new ArrayIterator([


### PR DESCRIPTION
Hi there,
I noticed a few minor improvements that we could make in the `Guard` class. 

---
1. `Guard::__construct` has a call that it initializes `$this->keyPair = null`. This can be moved to the property declaration without changing the functionality. 
2. There is one check for `$strength < 16` check, which can be moved to the top as well, so the later calls are not executed if we have to throw an exception. The early calls do not mutate state. 

---

3. `Guard::validateToken()` and `Guard::enforceStorageLimit()` methods have nested `if` calls, which can be removed in favor of early returns.

---

Fingers crossed this can be merged, and I'm open to make any further changes if necessary. Thank you for your time. 