### PR TITLE
Remove token on validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
   - composer install -n
 
 script:
-  - if [[ "$ANALYSIS" != 'true' ]]; then vendor/bin/phpunit ; fi
-  - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ "$ANALYSIS" != 'true' ]]; then XDEBUG_MODE=coverage ./vendor/bin/phpunit; fi
+  - if [[ "$ANALYSIS" == 'true' ]]; then XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
 
 after_success:
   - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/php-coveralls --coverage_clover=clover.xml -v ; fi

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -415,14 +415,13 @@ class Guard implements MiddlewareInterface
                 $value = $body[$this->getTokenValueKey()] ?? null;
             }
 
-            if ($name === null
-                || $value === null
-                || !$this->validateToken((string) $name, (string) $value)
-            ) {
-                if (!$this->persistentTokenMode && is_string($name)) {
-                    $this->removeTokenFromStorage($name);
-                }
+            $isValid = $this->validateToken((string) $name, (string) $value);
+            if ($isValid && !$this->persistentTokenMode) {
+                // successfully validated token, so delete it if not in persistentTokenMode
+                $this->removeTokenFromStorage($name);
+            }
 
+            if ($name === null || $value === null || !$isValid) {
                 $request = $this->appendNewTokenToRequest($request);
                 return $this->handleFailure($request, $handler);
             }

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -289,7 +289,8 @@ class GuardTest extends TestCase
         $requestHandlerProphecy = $this->prophesize(RequestHandlerInterface::class);
         $requestHandlerProphecy
             ->handle(Argument::type(ServerRequestInterface::class))
-            ->willReturn($responseProphecy->reveal());
+            ->willReturn($responseProphecy->reveal())
+            ->shouldBeCalledOnce();
 
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 


### PR DESCRIPTION
Ensure token is removed in persisent mode on validation

When the token is successfully validated and we are not in persistent mode, then we need to remove the token. This is a separate operation to handling failure.

The side-effect of the previous code is that is allowed a replay attack where the same token could be used multiple times even when persisent mode was disabled.

Thanks to @xhlika for the report.
