### PR TITLE
Support PHP 8 and remove 7.1 and 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.lock
 vendor
 coverage
+/.phpunit.result.cache
+/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
-dist: trusty
+dist: focal
 
 matrix:
   include:
-    - php: 7.1
-    - php: 7.2
     - php: 7.3
+      dist: xenial
     - php: 7.4
+    - php: 8.0
       env: ANALYSIS='true'
     - php: nightly
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
             "homepage": "http://joshlockhart.com"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^7.3|^8.0",
         "psr/http-factory": "^1.0",
@@ -20,10 +23,10 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
         "phpspec/prophecy": "^1.10",
-        "squizlabs/php_codesniffer": "^3.5.8",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.0",
+        "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,17 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3|^8.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.0",
         "phpspec/prophecy": "^1.10",
-        "squizlabs/php_codesniffer": "^3.5.8"
+        "squizlabs/php_codesniffer": "^3.5.8",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -13,6 +13,7 @@ use ArrayIterator;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,26 +25,28 @@ use Slim\Csrf\Guard;
 
 class GuardTest extends TestCase
 {
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage CSRF middleware instantiation failed. Minimum strength is 16.
-     */
+    use ProphecyTrait;
+
     public function testStrengthLowerThan16ThrowsException()
     {
         $storage = [];
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
-        $mw = new Guard($responseFactoryProphecy->reveal(), 'test', $storage, null, 200, 15);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('CSRF middleware instantiation failed. Minimum strength is 16.');
+        new Guard($responseFactoryProphecy->reveal(), 'test', $storage, null, 200, 15);
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Invalid CSRF storage.
      * Use session_start() before instantiating the Guard middleware or provide array storage.
      */
     public function testSetStorageThrowsExceptionWhenFallingBackOnSessionThatHasNotBeenStarted()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
-        $mw = new Guard($responseFactoryProphecy->reveal(), 'test');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid CSRF storage.');
+        new Guard($responseFactoryProphecy->reveal(), 'test');
     }
 
     /**
@@ -53,7 +56,7 @@ class GuardTest extends TestCase
     {
         session_start();
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
-        $mw = new Guard($responseFactoryProphecy->reveal(), 'test');
+        new Guard($responseFactoryProphecy->reveal(), 'test');
 
         $this->assertArrayHasKey('test', $_SESSION);
     }


### PR DESCRIPTION
Update to PHPUnit 9, which means we have to use the prophecy polyfill which is 7.3+ only, so drop support for 7.1 and 7.2.

We need to decide if this is a new minor version (1.2.0) or a new major version (2.0.0)

Fixes #128.