### PR TITLE
Implement iterator support at getLastKeyPair

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -297,11 +297,13 @@ class Guard implements MiddlewareInterface
             $value = $this->storage[$name];
             reset($this->storage);
         } elseif ($this->storage instanceof Iterator) {
+            $this->storage->rewind();
             while ($this->storage->valid()) {
+                $name = $this->storage->key();
+                $value = $this->storage->current();
                 $this->storage->next();
             }
-            $name = $this->storage->key();
-            $value = $this->storage->current();
+            $this->storage->rewind();
         }
 
         return $name !== null && $value !== null

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -289,10 +289,20 @@ class Guard implements MiddlewareInterface
             return null;
         }
 
-        end($this->storage);
-        $name = key($this->storage);
-        $value = $this->storage[$name];
-        reset($this->storage);
+        $name = null;
+        $value = null;
+        if (is_array($this->storage)) {
+            end($this->storage);
+            $name = key($this->storage);
+            $value = $this->storage[$name];
+            reset($this->storage);
+        } elseif ($this->storage instanceof Iterator) {
+            while ($this->storage->valid()) {
+                $this->storage->next();
+            }
+            $name = $this->storage->key();
+            $value = $this->storage->current();
+        }
 
         return $name !== null && $value !== null
             ? [

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -428,7 +428,6 @@ class GuardTest extends TestCase
 
     public function testCanGetLastKeyPairFromIterator()
     {
-
         $storage = new ArrayIterator([
             'test_key1' => 'value1',
             'test_key2' => 'value2',

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -425,4 +425,25 @@ class GuardTest extends TestCase
 
         $mw->process($requestProphecy->reveal(), $requestHandlerProphecy->reveal());
     }
+
+    public function testCanGetLastKeyPairFromIterator()
+    {
+
+        $storage = new ArrayIterator([
+            'test_key1' => 'value1',
+            'test_key2' => 'value2',
+        ]);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $mw = new Guard($responseFactoryProphecy->reveal(), 'test', $storage, null, 1);
+
+        $enforceStorageLimitMethod = new ReflectionMethod($mw, 'getLastKeyPair');
+        $enforceStorageLimitMethod->setAccessible(true);
+        $keyPair = $enforceStorageLimitMethod->invoke($mw);
+
+        $this->assertIsArray($keyPair);
+        $this->assertArrayHasKey('test_name', $keyPair);
+        $this->assertArrayHasKey('test_value', $keyPair);
+        $this->assertEquals('test_key2', $keyPair['test_name']);
+        $this->assertEquals('value2', $keyPair['test_value']);
+    }
 }


### PR DESCRIPTION
Hello together,

we use this Guard with our Redis iterator and the Key() method from php doesn't work with iterators that have there data not as properties.
So I implement the iterator support like in enforceStorageLimit method.

I'm not sure how travis work, what are open tasks for me?