### PR TITLE
Bug in enforcing storage limit, grew too large in many cases.

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -209,7 +209,7 @@ class Guard implements MiddlewareInterface
             $this->getTokenNameKey() => $name,
             $this->getTokenValueKey() => $value
         ];
-
+        $this->enforceStorageLimit();
         return $this->keyPair;
     }
 
@@ -388,6 +388,7 @@ class Guard implements MiddlewareInterface
     public function appendNewTokenToRequest(ServerRequestInterface $request): ServerRequestInterface
     {
         $token = $this->generateToken();
+        $this->enforceStorageLimit();
         return $this->appendTokenToRequest($request, $token);
     }
 
@@ -449,7 +450,6 @@ class Guard implements MiddlewareInterface
             $pair = $this->loadLastKeyPair() ? $this->keyPair : $this->generateToken();
             $request = $this->appendTokenToRequest($request, $pair);
         }
-
         $this->enforceStorageLimit();
 
         return $handler->handle($request);

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -388,7 +388,6 @@ class Guard implements MiddlewareInterface
     public function appendNewTokenToRequest(ServerRequestInterface $request): ServerRequestInterface
     {
         $token = $this->generateToken();
-        $this->enforceStorageLimit();
         return $this->appendTokenToRequest($request, $token);
     }
 


### PR DESCRIPTION
I had my storage limit to 10, and it grew way to large, only made size-check in specific cases. Moved the Check to when the script generates a new token pair