### PR TITLE
Bug fix: Enforce storage limit on failure

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -460,6 +460,7 @@ class Guard implements MiddlewareInterface
         } else {
             // Method is GET/OPTIONS/HEAD/etc, so do not accept the token in the body of this request
             if ($name !== null) {
+                $this->enforceStorageLimit();
                 return $this->handleFailure($request, $handler);
             }
         }


### PR DESCRIPTION
When a GET/OPTIONS/HEAD request with a body is provided, ensure that the storage limit is enforced.

Fixes #164