### PR TITLE
Bump psr/http-message requirement from '^1.0' to '^1.0 || ^2.0'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },


### PR DESCRIPTION
See title.

More details: https://github.com/odan/slim4-skeleton/issues/130