### PR TITLE
Increase uniqid entropy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ See https://github.com/slimphp/Slim-Csrf/releases for a full list
   underscore. This should not affect anyone who uses the relvant methods, but
   if you have hard-coded, then they will need to be updated.
 
+- Changed: Increased likelihood that tokens are unique. 
+
 ## 1.5.0
 
 - Added: Support for PHP 8.2 and 8.3

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -215,7 +215,7 @@ class Guard implements MiddlewareInterface
     public function generateToken(): array
     {
         // Generate new CSRF token
-        $name = uniqid($this->prefix);
+        $name = uniqid($this->prefix, true);
         $value = $this->createToken();
         $this->saveTokenToStorage($name, $value);
 


### PR DESCRIPTION
While we don't have that many tokens in play at any one time, this will increase the likelihood that the tokens are unique.
